### PR TITLE
update to erddap version 2.25.1

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -2,7 +2,7 @@
 version: "2"
 services:
   erddap:
-    image: "axiom/docker-erddap:2.23-jdk17-openjdk"
+    image: "axiom/docker-erddap:2.25.1-jdk21-openjdk"
     restart: always
     container_name: ${CONTAINER_NAME:-erddap}
     platform: linux/x86_64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "2"
 services:
   erddap:
-    image: "axiom/docker-erddap:2.24-jdk21-openjdk"
+    image: "axiom/docker-erddap:2.25.1-jdk21-openjdk"
     restart: always
     container_name: ${CONTAINER_NAME:-erddap}
     # platform: linux/x86_64


### PR DESCRIPTION
As per our discussion, this is an update to the ERDDAP version to enable downloading parquet files from the ERDDAP api