### PR TITLE
Fix: DasDds creates root-owned cache files preventing dataset loading

### DIFF
--- a/DasDds.sh
+++ b/DasDds.sh
@@ -5,5 +5,5 @@
 IFS='
 '
 export $(grep -v '^#' .env | xargs -d '\n')
-docker exec -it "${CONTAINER_NAME:-erddap}" bash -c "cd webapps/erddap/WEB-INF/ && bash DasDds.sh $*" \
+docker exec -it --user tomcat "${CONTAINER_NAME:-erddap}" bash -c "cd webapps/erddap/WEB-INF/ && bash DasDds.sh $*" \
   

--- a/datasets.d/development/HakaiWatershedsStreamStationsProvisional.xml
+++ b/datasets.d/development/HakaiWatershedsStreamStationsProvisional.xml
@@ -1,9 +1,6 @@
-<!-- NOTE! Since database tables don't have any metadata, you must add metadata
-  below, notably 'units' for each of the dataVariables. -->
 <dataset type="EDDTableFromDatabase" datasetID="HakaiWatershedsStreamStationsProvisional" active="true">
     <sourceUrl>hakai_erddap_sourceUrl</sourceUrl>
     <driverName>org.postgresql.Driver</driverName>
-    <catalogName>hakai</catalogName>
     <schemaName>erddap</schemaName>
     <tableName>"HakaiWatershedsStreamStations"</tableName>
     <reloadEveryNMinutes>10080</reloadEveryNMinutes>

--- a/datasets.d/development/HakaiWatershedsStreamStationsResearch.xml
+++ b/datasets.d/development/HakaiWatershedsStreamStationsResearch.xml
@@ -1,9 +1,6 @@
-<!-- NOTE! Since database tables don't have any metadata, you must add metadata
-  below, notably 'units' for each of the dataVariables. -->
 <dataset type="EDDTableFromDatabase" datasetID="HakaiWatershedsStreamStationsResearch" active="true">
     <sourceUrl>hakai_erddap_sourceUrl</sourceUrl>
     <driverName>org.postgresql.Driver</driverName>
-    <catalogName>hakai</catalogName>
     <schemaName>erddap</schemaName>
     <tableName>"HakaiWatershedsStreamStationsResearch"</tableName>
     <reloadEveryNMinutes>10080</reloadEveryNMinutes>


### PR DESCRIPTION
### Problem
The `HakaiWatershedsStreamStationsProvisional` dataset was failing to load in ERDDAP despite having proper database connectivity and XML configuration.

**Steps to find**
1. Dataset was missing from ERDDAP web interface
2. DasDds validation worked correctly (database connection confirmed)
3. Checked ERDDAP logs for specific dataset errors:
  ```bash
  docker exec -it erddap-development cat /erddapData/logs/log.txt | grep -i "HakaiWatershedsStreamStationsProvisional"
  ```
4. Found permission error:
  ```
  java.io.FileNotFoundException: /erddapData/cache/al/HakaiWatershedsStreamStationsProvisional/subset.nc.1241755147.station.temp (Permission denied)
  ```

Running DasDds via `docker exec` (without specifying user) executes as root, creating root-owned cache files. However, the main ERDDAP process runs as the `tomcat` user and cannot write to root-owned directories so my solution was to always run DasDds as the tomcat user.

