### PR TITLE
Update sentinel_3A_POLYMER.xml

### DIFF
--- a/datasets.d/sentinel_3A_POLYMER.xml
+++ b/datasets.d/sentinel_3A_POLYMER.xml
@@ -6,7 +6,7 @@
     <recursive>true</recursive>
     <pathRegex>.*</pathRegex>
     <metadataFrom>last</metadataFrom>
-    <matchAxisNDigits>20</matchAxisNDigits>
+    <matchAxisNDigits>10</matchAxisNDigits>
     <fileTableInMemory>false</fileTableInMemory>
     <accessibleViaWMS>true</accessibleViaWMS>
     <!-- sourceAttributes>


### PR DESCRIPTION
Reduce required coordinate precision for 1-day algae explorer outputs.

After updating some packages, these are sometimes off on the scale of fractions of a millimeter.