### PR TITLE
Fix git pull command in erddap_create_views.sh

### DIFF
--- a/erddap_create_views.sh
+++ b/erddap_create_views.sh
@@ -8,7 +8,7 @@
 #
 # Contact Nate if there are issues with this script
 
-git --git-dir hakai-erddap/.git pull
+git --git-dir hakai-erddap/.git --work-tree hakai-erddap pull
 
 export PGUSER=$(cat .pguser)
 export PGPASSWORD=$(cat .pgpass)


### PR DESCRIPTION
The current git pull command uses `--git-dir` without `--work-tree`, causing git  to assume the working tree is the current directory (HOME) rather than the repository directory. This creates phantom file differences and prevents 
pulling when Git thinks there are uncommitted local changes.

This fix will explicitly tells git where both the .git directory and working files are which will hopefully resolve some nightly failures. 

Tagging @n-a-t-e because his name is literally in the script. 